### PR TITLE
tron-endpoints option now allows using multiple schema

### DIFF
--- a/cmd/firetron/fetcher.go
+++ b/cmd/firetron/fetcher.go
@@ -62,7 +62,10 @@ func fetchE(cmd *cobra.Command, args []string) error {
 	tronClients := firecoreRPC.NewClients(maxBlockFetchDuration, rollingStrategy, logger)
 
 	for _, endpoint := range rpcEndpoints {
-		client := rpc.NewTronClient(endpoint, apiKey)
+		client, err := rpc.NewTronClient(endpoint, apiKey)
+		if err != nil {
+			return fmt.Errorf("failed to create Tron client for endpoint %q: %w", endpoint, err)
+		}
 		tronClients.Add(client)
 	}
 

--- a/cmd/firetron/testblock.go
+++ b/cmd/firetron/testblock.go
@@ -74,7 +74,10 @@ func testBlockE(cmd *cobra.Command, args []string) error {
 
 	rollingStrategy := firecoreRPC.NewStickyRollingStrategy[pbtronapi.WalletClient]()
 	tronClients := firecoreRPC.NewClients(maxBlockFetchDuration, rollingStrategy, logger)
-	client := rpc.NewTronClient(rpcEndpoint, apiKey)
+	client, err := rpc.NewTronClient(rpcEndpoint, apiKey)
+	if err != nil {
+		return fmt.Errorf("failed to create Tron client: %w", err)
+	}
 	tronClients.Add(client)
 
 	// Create Tron clients with all endpoints

--- a/rpc/fetcher.go
+++ b/rpc/fetcher.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	pbbstream "github.com/streamingfast/bstream/pb/sf/bstream/v1"
-	"github.com/streamingfast/cli"
 	"github.com/streamingfast/dgrpc"
 	"github.com/streamingfast/firehose-core/blockpoller"
 	firecoreRPC "github.com/streamingfast/firehose-core/rpc"
@@ -47,10 +46,10 @@ func (c *apiKeyCredentials) RequireTransportSecurity() bool {
 	return false
 }
 
-func NewTronClient(endpointURL string, apiKey string) pbtronapi.WalletClient {
+func NewTronClient(endpointURL string, apiKey string) (pbtronapi.WalletClient, error) {
 	parsedURL, err := url.Parse(endpointURL)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to parse endpoint URL %q: %v", endpointURL, err))
+		return nil, fmt.Errorf("failed to parse endpoint URL %q: %w", endpointURL, err)
 	}
 
 	var grpcOptions []grpc.DialOption
@@ -88,9 +87,11 @@ func NewTronClient(endpointURL string, apiKey string) pbtronapi.WalletClient {
 	}
 
 	conn, err := dgrpc.NewExternalClientConn(hostWithPort, grpcOptions...)
-	cli.NoError(err, "Failed to create client connection")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client connection: %w", err)
+	}
 
-	return pbtronapi.NewWalletClient(conn)
+	return pbtronapi.NewWalletClient(conn), nil
 }
 
 func NewFetcher(


### PR DESCRIPTION
You can now use `--tron-endpoints` with `http` and `https` and the client will be setup correctly.
If no ports are specified in the endpoint URL, it defaults to `80` for HTTP and `443` for HTTPS.
We also parse query on HTTPS if you want to use an insecure connection. Simply use `insecure=true` in your endpoint.
